### PR TITLE
Changes to allow Travis CI and Coveralls integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo:required
+sudo: required
 dist: trusty
 language: node_js
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+sudo:required
+dist: trusty
 language: node_js
 node_js:
   - v6
   - v5
-  - v4
-  - '0.12'
-  - '0.10'
+before_install:
+  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+  - sudo apt-get -qq update
+  - sudo apt-get install dotnet-dev-1.0.0-preview2-003131 -y

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var mocha = require('gulp-mocha');
 var istanbul = require('gulp-istanbul');
 var nsp = require('gulp-nsp');
 var plumber = require('gulp-plumber');
+var coveralls = require('gulp-coveralls');
 
 gulp.task('static', function () {
   return gulp.src('**/*.js')
@@ -44,9 +45,18 @@ gulp.task('test', ['pre-test'], function (cb) {
     });
 });
 
+gulp.task('coveralls', ['test'], function () {
+  if (!process.env.CI) {
+    return;
+  }
+
+  return gulp.src(path.join(__dirname, 'coverage/lcov.info'))
+    .pipe(coveralls());
+});
+
 gulp.task('watch', function () {
   gulp.watch(['generators/**/*.js', 'test/**'], ['test']);
 });
 
 gulp.task('prepublish', ['nsp']);
-gulp.task('default', ['static', 'test']);
+gulp.task('default', ['static', 'test', 'coveralls']);

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "repository": "agc93/generator-cake",
   "scripts": {
+    "prepublish": "gulp prepublish",
     "test": "gulp"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-cake",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Yeoman generator for Cake build scripts",
   "homepage": "https://github.com/agc93/generator-cake/",
   "author": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "gulp-istanbul": "^1.0.0",
     "gulp-mocha": "^2.0.0",
     "gulp-plumber": "^1.0.0",
-    "gulp-nsp": "^2.1.0"
+    "gulp-nsp": "^2.1.0",
+    "gulp-coveralls": "^0.1.4"
   },
   "eslintConfig": {
     "extends": "xo-space",
@@ -52,7 +53,6 @@
   },
   "repository": "agc93/generator-cake",
   "scripts": {
-    "prepublish": "gulp prepublish",
     "test": "gulp"
   },
   "license": "MIT",

--- a/test/common.js
+++ b/test/common.js
@@ -14,7 +14,7 @@ const shared = {
       ]);
     },
     areDownloaded() {
-      assert.fileContent('cake.config', 'https://github.com/cake-build/resource');
+      assert.fileContent('cake.config', 'https://github.com/cake-build/resources');
     },
     areLocal() {
       assert.fileContent('cake.config', 'generator-cake');
@@ -35,8 +35,8 @@ const shared = {
       ]);
     },
     areDownloaded() {
-      assert.fileContent('build.ps1', 'https://github.com/cake-build/resource');
-      assert.fileContent('build.sh', 'https://github.com/cake-build/resource');
+      assert.fileContent('build.ps1', 'https://github.com/cake-build/resources');
+      assert.fileContent('build.sh', 'https://github.com/cake-build/resources');
     },
     areLocal() {
       assert.fileContent('build.ps1', 'generator-cake');


### PR DESCRIPTION
Fixes the default .travis.yml so that this can be used with dotnet core. This allows automated CI builds using https://travis-ci.org and test coverage using https://coveralls.io

See [here ](https://travis-ci.org/frozenskys/generator-cake) and [here ](https://coveralls.io/github/frozenskys/generator-cake) for examples using my fork.

Also includes the fix for the cake-build resources in the unit tests from [PR#2](https://github.com/agc93/generator-cake/pull/2)
